### PR TITLE
add custom template to Hacienda to fix GU16 crash

### DIFF
--- a/[Gameplay] New World Tourism/data/config/export/main/asset/templates.xml
+++ b/[Gameplay] New World Tourism/data/config/export/main/asset/templates.xml
@@ -1,0 +1,5 @@
+<ModOps>
+  <ModOp Type="add" Path="//Template[Name='Hacienda']/Properties">
+    <BusActivation />
+  </ModOp>
+</ModOps>


### PR DESCRIPTION
Modifying the template seems the better option here so that other mods may add something as well.

Drawback: buildings which use Hacienda and not their copy would get bus activation.


ps. It's the only Template mismatch I found.